### PR TITLE
fix encoding error in R files that fails install_github in R

### DIFF
--- a/R/BetaDiv.R
+++ b/R/BetaDiv.R
@@ -117,7 +117,8 @@ if (method == "RDA") {
   ordi=ordinate(ps1_rela, method=method, distance=dist)
   #样本坐标,这里可选u或者v矩阵
   points=ordi$CA$v[,1:2]
-  colnames(points)=c("x", "y") #命名行名
+  #命名行名
+  colnames(points)=c("x", "y")
   #提取特征值
   eig=ordi$CA$eig
 }
@@ -167,7 +168,8 @@ if (method == "LDA") {
   ord_in=model
   axes=c(1:2)
   points=data.frame(predict(ord_in)$x[, axes])
-  colnames(points)=c("x", "y") #命名行名
+  # 命名行名
+  colnames(points)=c("x", "y")
   # 提取解释度
   eig= ord_in$svd^2
 }
@@ -198,7 +200,8 @@ if (method == "t-sne") {
   # 提取坐标
   points=as.data.frame(tsne$Y)
   row.names(points)= row.names(map)
-  colnames(points)=c("x", "y") #命名行名
+  # 命名行名
+  colnames(points)=c("x", "y")
   stress= NULL
 }
 

--- a/R/tax_stack_cluster.R
+++ b/R/tax_stack_cluster.R
@@ -48,10 +48,14 @@ tax_stack_clust <- function(
          tax=NULL,
          dist="bray",
          Group="Group",
-         j="Phylum", # 使用门水平绘制丰度图表
-         rep=6 ,# 重复数量是6个
-         Top=10, # 提取丰度前十的物种注释
-         tran=TRUE, # 转化为相对丰度值
+         # 使用门水平绘制丰度图表
+         j="Phylum",
+         # 重复数量是6个
+         rep=6,
+         # 提取丰度前十的物种注释
+         Top=10,
+         # 转化为相对丰度值
+         tran=TRUE,
          hcluter_method="complete",
          cuttree=3){
 


### PR DESCRIPTION
amplicon package successfully using install_github() after this bugfix.

```
> install_github("wolvesled/amplicon")
Downloading GitHub repo wolvesled/amplicon@HEAD
√  checking for file 'C:\***\wolvesled-amplicon-5a8c302/DESCRIPTION' (428ms)
-  preparing 'amplicon': (542ms)
√  checking DESCRIPTION meta-information ... 
-  checking for LF line-endings in source and make files and shell scripts
-  checking for empty or unneeded directories
-  building 'amplicon_1.1.4.tar.gz'
   
Installing package into ‘C:/***/R/win-library/4.0’
(as ‘lib’ is unspecified)
* installing *source* package 'amplicon' ...
** using staged installation
** R
** data
*** moving datasets to lazyload DB
** byte-compile and prepare package for lazy loading
Note: possible error in 'alpha(psRe, index = method)': unused argument (index = method) 
** help
*** installing help indices
  converting help for package 'amplicon'
    finding HTML links ... done
    BetaDiv                                 html  
    MicroTest                               html  
    RDA_CCA                                 html  
    alpha_barplot                           html  
    alpha_boxplot                           html  
    alpha_rare_all                          html  
    alpha_rare_curve                        html  
    alpha_sample_rare                       html  
    beta_cpcoa                              html  
    beta_cpcoa_dis                          html  
    beta_pcoa                               html  
    beta_pcoa_stat                          html  
    compare                                 html  
    format2lefse                            html  
    format2lefse2                           html  
    format2maptree                          html  
    format2stamp                            html  
    pairMicroTest                           html  
    tax_circlize                            html  
    tax_maptree                             html  
    finding level-2 HTML links ... done

Rd warning: C:/***/tax_maptree.Rd:19: missing link '1'
    tax_stack_clust                         html  
    tax_stackplot                           html  
    tax_wordcloud                           html  
** building package indices
** installing vignettes
** testing if installed package can be loaded from temporary location
*** arch - i386
*** arch - x64
** testing if installed package can be loaded from final location
*** arch - i386
*** arch - x64
** testing if installed package keeps a record of temporary installation path
* DONE (amplicon)
```