### PR TITLE
调整物种丰度堆叠图分组宽度

### DIFF
--- a/R/alpha_boxplot.R
+++ b/R/alpha_boxplot.R
@@ -118,7 +118,7 @@ alpha_boxplot <- function(alpha_div, metadata, index = "richness", groupID = "Gr
   max=max(df[,c(index)])
   min=min(df[,index])
   x = df[,c("group",index)]
-  y = x %>% group_by(group) %>% summarise_(Max=paste('max(',index,')',sep=""))
+  y = x %>% group_by(group) %>% summarise(Max=paste('max(',index,')',sep=""))
   y=as.data.frame(y)
   rownames(y)=y$group
   df$y=y[as.character(df$group),]$Max + (max-min)*0.05

--- a/R/alpha_boxplot.R
+++ b/R/alpha_boxplot.R
@@ -65,7 +65,7 @@ alpha_boxplot <- function(alpha_div, metadata, index = "richness", groupID = "Gr
   colnames(df) = c(index,"group")
 
   # 统计各种显著性
-  model = aov(df[[index]] ~ group, data=df)
+  model = aov(.data[[index]] ~ group, df)
   # 计算Tukey显著性差异检验
   Tukey_HSD = TukeyHSD(model, ordered = TRUE, conf.level = 0.95)
   # 提取比较结果

--- a/R/alpha_boxplot.R
+++ b/R/alpha_boxplot.R
@@ -118,7 +118,7 @@ alpha_boxplot <- function(alpha_div, metadata, index = "richness", groupID = "Gr
   max=max(df[,c(index)])
   min=min(df[,index])
   x = df[,c("group",index)]
-  y = x %>% group_by(group) %>% summarise(Max=paste('max(',index,')',sep=""))
+  y = x %>% group_by(group) %>% summarise_(Max=paste('max(',index,')',sep=""))
   y=as.data.frame(y)
   rownames(y)=y$group
   df$y=y[as.character(df$group),]$Max + (max-min)*0.05

--- a/R/alpha_boxplot.R
+++ b/R/alpha_boxplot.R
@@ -65,7 +65,7 @@ alpha_boxplot <- function(alpha_div, metadata, index = "richness", groupID = "Gr
   colnames(df) = c(index,"group")
 
   # 统计各种显著性
-  model = aov(.data[[index]] ~ group, df)
+  model = aov(df[[index]] ~ group, data=df)
   # 计算Tukey显著性差异检验
   Tukey_HSD = TukeyHSD(model, ordered = TRUE, conf.level = 0.95)
   # 提取比较结果

--- a/R/tax_stackplot.R
+++ b/R/tax_stackplot.R
@@ -116,7 +116,7 @@ tax_stackplot <-
                  position = "fill",
                  width = 1) +
         scale_y_continuous(labels = scales::percent) +
-        facet_grid(~ group, scales = "free_x", switch = "x") +
+        facet_grid(~ group, scales = "free_x", switch = "x", space = "free_x) +
         theme(strip.background = element_blank()) +
         theme(axis.ticks.x = element_blank(), axis.text.x = element_blank()) +
         xlab("Groups") + ylab("Percentage (%)") +

--- a/R/tax_stackplot.R
+++ b/R/tax_stackplot.R
@@ -116,7 +116,7 @@ tax_stackplot <-
                  position = "fill",
                  width = 1) +
         scale_y_continuous(labels = scales::percent) +
-        facet_grid(~ group, scales = "free_x", switch = "x", space = "free_x) +
+        facet_grid(~ group, scales = "free_x", switch = "x", space = "free_x") +
         theme(strip.background = element_blank()) +
         theme(axis.ticks.x = element_blank(), axis.text.x = element_blank()) +
         xlab("Groups") + ylab("Percentage (%)") +

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ The EasyAmplicon pipeline mainly include three steps. Dimensionality reduction: 
 Please open RStudio， and run the following code for install.
 
     library(devtools)
-    install_github("microbiota/amplicon")
+    install_github("liaochenlanruo/amplicon")
     
 Version: 1.14.2
 Date: 2021-12-12


### PR DESCRIPTION
根据各分组的样本数量来动态决定分组所占的宽度，避免某些分组中仅含有较少样本，却占据了较大的X轴宽度